### PR TITLE
Fix the layout of the chat container

### DIFF
--- a/webfront/index.html
+++ b/webfront/index.html
@@ -300,20 +300,18 @@
         </div>
       </div>
 
-      <div id="chatContainer" class="row">
-        <div class="button-container" id="login"></div>
+      <div id="chatContainer" class="row overflow-hidden">
+        <div class="button-container col-12" id="login"></div>
 
         <!-- Chat Boxes -->
-        <div class="section-chat-boxes">
+        <div class="section-chat-boxes col-12 d-flex flex-column overflow-hidden">
           <!-- Live Chat -->
-          <div class="col-md-12">
-            <div class="panel panel-primary">
-              <div class="panel-heading panelHeading">Live Chat</div>
+          <div class="panel panel-primary row d-flex flex-column overflow-hidden flex-nowrap">
+            <div class="panel-heading panelHeading col-12">Live Chat</div>
 
-              <div class="live-chat-wrapper">
-                <div id="livechatc" class="panel-body panelBody">
-                  <div class="subscribe" id="livechat"></div>
-                </div>
+            <div class="live-chat-wrapper col-12 d-flex flex-column overflow-hidden flex-nowrap">
+              <div id="livechatc" class="panel-body panelBody">
+                <div class="subscribe" id="livechat"></div>
               </div>
             </div>
           </div>
@@ -503,7 +501,7 @@
           chatContainer.style.display = "none";
         } else {
           menu.style.display = "none";
-          chatContainer.style.display = "block";
+          chatContainer.style.display = "";
         }
       }
 

--- a/webfront/styles.css
+++ b/webfront/styles.css
@@ -18,7 +18,6 @@ html, body, * {
 
 .section-chat-boxes {
   flex: 1;
-  padding: 0;
 }
 
 table {
@@ -85,7 +84,6 @@ table td {
 
 .panelBody {
   min-height: 450px;
-  max-height: 450px;
   overflow-y: scroll;
 }
 
@@ -105,8 +103,8 @@ table td {
 
 .live-chat-wrapper {
   position: relative;
-  height: 100%;
   padding: 10px;
+  flex: 1;
 }
 
 


### PR DESCRIPTION
Fixes the layout for the chat container to properly span the height of the window.

Also fixes the footer moving up when the settings are closed.
