### PR TITLE
Update checkboxes

### DIFF
--- a/webfront/index.html
+++ b/webfront/index.html
@@ -61,7 +61,7 @@
             <div class="row" style="padding: 20px">
               <div class="col-md-6">
                 <div class="form-group">
-                  <dt>Token credentials:</dt>
+                  <dt><label for="twitch_username">Token credentials:</label></dt>
                   <dd class="clearfix">
                     <input
                       type="text"
@@ -78,205 +78,248 @@
 
                 <div id="dstLangPlaceholder" class="form-group"></div>
 
-                <div class="form-group">
-                  <input type="checkbox" id="cbSpeak" onchange="saveCheckbox(event)" value="Speak" checked />
-                  TTS Enabled
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="cbSpeak" onchange="saveCheckbox(event)" value="Speak" checked />
+                  <label class="form-check-label" for="cbSpeak">
+                    TTS Enabled
+                  </label>
                 </div>
 
-                <div class="form-group">
-                  <input type="checkbox" id="cbAutoTranslateChat" onchange="saveCheckbox(event)" />
-                  Auto translate chat and output to channel (Be aware this will send translations to any channel
-                  connected)
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="cbAutoTranslateChat" onchange="saveCheckbox(event)" />
+                  <label class="form-check-label" for="cbAutoTranslateChat">
+                    Auto translate chat and output to channel (Be aware this will send translations to any channel connected)
+                  </label>
                 </div>
 
-                <div class="form-group">
-                  <input type="checkbox" id="cbDeleteCommands" onchange="saveCheckbox(event)" />
-                  Delete all channel commands that start with !
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="cbDeleteCommands" onchange="saveCheckbox(event)" />
+                  <label class="form-check-label" for="cbDeleteCommands">
+                    Delete all channel commands that start with !
+                  </label>
                 </div>
 
-                <div class="form-group">
-                  <input type="checkbox" id="cbEveryoneTTS" onchange="saveCheckbox(event)" checked />
-                  Allow Everyone to use TTS
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="cbEveryoneTTS" onchange="saveCheckbox(event)" checked />
+                  <label class="form-check-label" for="cbEveryoneTTS">
+                    Allow Everyone to use TTS
+                  </label>
                 </div>
 
-                <div class="form-group">
-                  <input type="checkbox" id="cbModTTS" onchange="saveCheckbox(event)" checked />
-                  Allow Mods to use TTS
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="cbModTTS" onchange="saveCheckbox(event)" checked />
+                  <label class="form-check-label" for="cbModTTS">
+                    Allow Mods to use TTS
+                  </label>
                 </div>
 
-                <div class="form-group">
-                  <input type="checkbox" id="cbVipTTS" onchange="saveCheckbox(event)" checked />
-                  Allow Vips to use TTS
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="cbVipTTS" onchange="saveCheckbox(event)" checked />
+                  <label class="form-check-label" for="cbVipTTS">
+                    Allow Vips to use TTS
+                  </label>
                 </div>
 
-                <div class="form-group">
-                  <input type="checkbox" id="cbSubTTS" onchange="saveCheckbox(event)" checked />
-                  Allow Subs to use TTS
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="cbSubTTS" onchange="saveCheckbox(event)" checked />
+                  <label class="form-check-label" for="cbSubTTS">
+                    Allow Subs to use TTS
+                  </label>
                 </div>
 
-                <div class="form-group">
-                  <input type="checkbox" id="cbSpeakReplies" onchange="saveCheckbox(event)" />
-                  Speak replies and @name references at start of message.
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="cbSpeakReplies" onchange="saveCheckbox(event)" />
+                  <label class="form-check-label" for="cbSpeakReplies">
+                    Speak replies and @name references at start of message.
+                  </label>
                 </div>
 
-                <div class="form-group">
-                  <input type="checkbox" id="cbSpeakEmotesTTS" onchange="saveCheckbox(event)" checked />
-                  Speak emotes
-                  <input type="checkbox" id="cbDedupEmotesTTS" onchange="saveCheckbox(event)" checked />
-                  Dedup emotes
+                <div class="form-check d-inline-block">
+                  <input class="form-check-input" type="checkbox" id="cbSpeakEmotesTTS" onchange="saveCheckbox(event)" checked />
+                  <label class="form-check-label" for="cbSpeakEmotesTTS">
+                    Speak emotes
+                  </label>
+                </div>
+                <div class="form-check d-inline-block">
+                  <input class="form-check-input" type="checkbox" id="cbDedupEmotesTTS" onchange="saveCheckbox(event)" checked />
+                  <label class="form-check-label" for="cbDedupEmotesTTS">
+                    Dedup emotes
+                  </label>
                 </div>
 
-                <div class="form-group">
-                  <input type="checkbox" id="cbCleanupTranslation" onchange="saveCheckbox(event)" />
-                  If translation is identical to original message don't translate.
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="cbCleanupTranslation" onchange="saveCheckbox(event)" />
+                  <label class="form-check-label" for="cbCleanupTranslation">
+                    If translation is identical to original message don't translate.
+                  </label>
                 </div>
 
-                <div class="form-group">
-                  <input type="checkbox" id="cbUserLevDistance" onchange="saveCheckbox(event)" checked />
-                  Don't speak user message if they are a % similar to the last messages in the last X seconds.
-                  (Levenshtein distance)
-                  <br />
-                  <label for="txtUserLevPct"
-                    >Percent:
-                    <input
-                      style="display: inline-block; width: 75px"
-                      type="number"
-                      size="5"
-                      id="txtUserLevPct"
-                      class="form-control"
-                      value="90"
-                      placeholder="90"
-                      oninput="saveTextField(event)"
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="cbUserLevDistance" onchange="saveCheckbox(event)" checked />
+                  <label class="form-check-label" for="cbUserLevDistance">
+                    Don't speak user message if they are a % similar to the last messages in the last X seconds.
+                    (Levenshtein distance)
+                  </label>
+                </div>
+                <label for="txtUserLevPct"
+                >Percent:
+                  <input
+                    style="display: inline-block; width: 75px"
+                    type="number"
+                    size="5"
+                    id="txtUserLevPct"
+                    class="form-control"
+                    value="90"
+                    placeholder="90"
+                    oninput="saveTextField(event)"
                   /></label>
-                  <label for="txtUserLevTime">
-                    Time:
-                    <input
-                      style="display: inline-block; width: 75px"
-                      type="number"
-                      size="5"
-                      id="txtUserLevTime"
-                      class="form-control"
-                      value="300"
-                      placeholder="300"
-                      oninput="saveTextField(event)"
+                <label for="txtUserLevTime">
+                  Time:
+                  <input
+                    style="display: inline-block; width: 75px"
+                    type="number"
+                    size="5"
+                    id="txtUserLevTime"
+                    class="form-control"
+                    value="300"
+                    placeholder="300"
+                    oninput="saveTextField(event)"
                   /></label>
-                </div>
 
-                <div class="form-group">
-                  <input type="checkbox" id="cbChatLevDistance" onchange="saveCheckbox(event)" checked />
-                  Don't speak chat messages if they are a % similar to the last messages in the last X seconds.
-                  (Levenshtein distance)
-                  <br />
-                  <label for="txtChatLevPct"
-                    >Percent:
-                    <input
-                      style="display: inline-block; width: 75px"
-                      type="number"
-                      size="5"
-                      id="txtChatLevPct"
-                      class="form-control"
-                      value="90"
-                      placeholder="90"
-                      oninput="saveTextField(event)"
-                  /></label>
-                  <label for="txtChatLevTime">
-                    Time:
-                    <input
-                      style="display: inline-block; width: 75px"
-                      type="number"
-                      size="5"
-                      id="txtChatLevTime"
-                      class="form-control"
-                      value="300"
-                      placeholder="300"
-                      oninput="saveTextField(event)"
-                  /></label>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="cbChatLevDistance"
+                         onchange="saveCheckbox(event)" checked/>
+                  <label class="form-check-label" for="cbChatLevDistance">
+                    Don't speak chat messages if they are a % similar to the last messages in the last X seconds.
+                    (Levenshtein distance)
+                  </label>
                 </div>
+                <label for="txtChatLevPct"
+                >Percent:
+                  <input
+                    style="display: inline-block; width: 75px"
+                    type="number"
+                    size="5"
+                    id="txtChatLevPct"
+                    class="form-control"
+                    value="90"
+                    placeholder="90"
+                    oninput="saveTextField(event)"
+                  /></label>
+                <label for="txtChatLevTime">
+                  Time:
+                  <input
+                    style="display: inline-block; width: 75px"
+                    type="number"
+                    size="5"
+                    id="txtChatLevTime"
+                    class="form-control"
+                    value="300"
+                    placeholder="300"
+                    oninput="saveTextField(event)"
+                  /></label>
               </div>
 
               <div class="col-md-6">
                 <div class="form-group">
                   These options require microphone access:<br />
-                  <input type="checkbox" id="cbPauseTTSOnSpeech" onchange="saveCheckbox(event)" checked />
-                  Pause TTS when speaking. (Must allow mic access and choose correct mic input)
-                  <br />
-                  <div class="form-group">
-                    <input type="checkbox" id="cbPoofMessage" onchange="saveCheckbox(event)" />
-                    Say "poof" message to stop speaking a message and continue.<br />
-                    <input
-                      type="text"
-                      size="80"
-                      id="txtPoofRegex"
-                      class="form-control"
-                      value="(poof|proof|poop)"
-                      placeholder="example regex: (poof|proof|poop)"
-                      onchange="saveTextField(event)"
-                    />
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="cbPauseTTSOnSpeech" onchange="saveCheckbox(event)" checked />
+                    <label class="form-check-label" for="cbPauseTTSOnSpeech">
+                      Pause TTS when speaking. (Must allow mic access and choose correct mic input)
+                    </label>
                   </div>
-                  <div class="form-group">
-                    <input type="checkbox" id="cbBanHammer" onchange="saveCheckbox(event)" />
-                    Say "ban" message to stop speaking and speak "ban confirmation" message.
 
-                    <input
-                      type="text"
-                      size="80"
-                      id="txtBanRegex"
-                      class="form-control"
-                      value="(band hammer|ben hammer|ban hammer|banhammer|ben hammer|jan hammer)"
-                      placeholder="example regex: (ben hammer|ban hammer|banhammer|ben hammer|jan hammer)"
-                      oninput="saveTextField(event)"
-                    /><br />
-                    <input
-                      type="text"
-                      size="80"
-                      id="txtBanConfirmRegex"
-                      class="form-control"
-                      value="(affirmative)"
-                      placeholder="example regex: (affirmative)"
-                      oninput="saveTextField(event)"
-                    />
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="cbPoofMessage" onchange="saveCheckbox(event)" />
+                    <label class="form-check-label" for="cbPoofMessage">
+                      Say "poof" message to stop speaking a message and continue.
+                    </label>
                   </div>
-                  <br />
-                  <input type="checkbox" id="cbSTTS" onchange="saveCheckbox(event)" />
-                  Use Webkit Voice Recognition and speak result in system language and voice. (Must allow mic access and
-                  choose correct mic input)
-                  <br />
-                  <input type="checkbox" id="cbSendDictationTranslation" onchange="saveCheckbox(event)" />
-                  Send Dictation Text and Translation to Channel (Be aware this will send translations to any channel
-                  connected)
-                  <br />
+                  <label class="d-block mb-1"><input
+                    type="text"
+                    size="80"
+                    id="txtPoofRegex"
+                    class="form-control"
+                    value="(poof|proof|poop)"
+                    placeholder="example regex: (poof|proof|poop)"
+                    onchange="saveTextField(event)"
+                  /></label>
 
-                  <input
-                    type="checkbox"
-                    id="cbSendTextToWebsocket"
-                    onchange="saveCheckbox(event); enableCustomWebsocket(this.checked);"
-                  />
-                  Send spoken text to websocket for comannds.
-                  <br />
-                  <input
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="cbBanHammer" onchange="saveCheckbox(event)" />
+                    <label class="form-check-label" for="cbBanHammer">
+                      Say "ban" message to stop speaking and speak "ban confirmation" message.
+                    </label>
+                  </div>
+                  <label class="d-block mb-4"><input
+                    type="text"
+                    size="80"
+                    id="txtBanRegex"
+                    class="form-control"
+                    value="(band hammer|ben hammer|ban hammer|banhammer|ben hammer|jan hammer)"
+                    placeholder="example regex: (ben hammer|ban hammer|banhammer|ben hammer|jan hammer)"
+                    oninput="saveTextField(event)"
+                  /></label>
+                  <label class="d-block mb-4"><input
+                    type="text"
+                    size="80"
+                    id="txtBanConfirmRegex"
+                    class="form-control"
+                    value="(affirmative)"
+                    placeholder="example regex: (affirmative)"
+                    oninput="saveTextField(event)"
+                  /></label>
+
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="cbSTTS" onchange="saveCheckbox(event)" />
+                    <label class="form-check-label" for="cbSTTS">
+                      Use Webkit Voice Recognition and speak result in system language and voice. (Must allow mic access and
+                      choose correct mic input)
+                    </label>
+                  </div>
+
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="cbSendDictationTranslation" onchange="saveCheckbox(event)" />
+                    <label class="form-check-label" for="cbSendDictationTranslation">
+                      Send Dictation Text and Translation to Channel (Be aware this will send translations to any channel
+                      connected)
+                    </label>
+                  </div>
+
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" id="cbSendTextToWebsocket"
+                           onchange="saveCheckbox(event); enableCustomWebsocket(this.checked);"
+                    />
+                    <label class="form-check-label" for="cbSendTextToWebsocket">
+                      Send spoken text to websocket for comannds.
+                    </label>
+                  </div>
+                  <label class="d-block mb-4"><input
                     type="text"
                     id="txtWebsocketURL"
                     class="form-control"
                     value="ws://localhost:1880/stt"
                     placeholder="ws://localhost:1880/stt"
-                  />
-                  <br />
+                  /></label>
 
-                  <input
-                    type="checkbox"
-                    id="cbSendTextToAWSWebsocket"
-                    onchange="saveCheckbox(event); enableAWSWebsocket(this.checked);"
-                  />
-                  Send spoken text to AWS for end user clients.
-                  <br />
-                  <input
+                  <div class="form-check">
+                    <input class="form-check-input"
+                      type="checkbox"
+                      id="cbSendTextToAWSWebsocket"
+                      onchange="saveCheckbox(event); enableAWSWebsocket(this.checked);"
+                    />
+                    <label class="form-check-label" for="cbSendTextToAWSWebsocket">
+                      Send spoken text to AWS for end user clients.
+                    </label>
+                  </div>
+                  <label class="d-block mb-4"><input
                     type="text"
                     id="txtAWSWebsocketURL"
                     class="form-control"
                     value="wss://api.tts.bot"
                     placeholder="wss://api.tts.bot"
-                  />
-                  <br />
+                  /></label>
 
                   <a href="node-red-example-command-flow.json">Example Node-RED Command Flow</a>
                 </div>
@@ -284,15 +327,14 @@
                 <div id="systemLangPlaceholder"></div>
                 <div id="systemVoicePlaceholder"></div>
                 <br />
-                <input
+                <label class="d-block mb-4"><input
                   type="text"
                   id="txtCCTURL"
                   class="form-control"
                   value="https://securitylive.com/translator.html?popup=true&src=en&dst=de&webkit-text-stroke-color=red&outline-color=red&shadow-color=red&border-color=red"
                   placeholder="test"
-                />
+                /></label>
 
-                <br />
                 <input type="button" value="Open Dictation Window" onclick="OpenPopup()" />
               </div>
             </div>

--- a/webfront/index.html
+++ b/webfront/index.html
@@ -79,83 +79,83 @@
                 <div id="dstLangPlaceholder" class="form-group"></div>
 
                 <div class="form-check">
-                  <input class="form-check-input" type="checkbox" id="cbSpeak" onchange="saveCheckbox(event)" value="Speak" checked />
+                  <input class="form-check-input" type="checkbox" id="cbSpeak" onchange="saveCheckbox(this)" value="Speak" checked />
                   <label class="form-check-label" for="cbSpeak">
                     TTS Enabled
                   </label>
                 </div>
 
                 <div class="form-check">
-                  <input class="form-check-input" type="checkbox" id="cbAutoTranslateChat" onchange="saveCheckbox(event)" />
+                  <input class="form-check-input" type="checkbox" id="cbAutoTranslateChat" onchange="saveCheckbox(this)" />
                   <label class="form-check-label" for="cbAutoTranslateChat">
                     Auto translate chat and output to channel (Be aware this will send translations to any channel connected)
                   </label>
                 </div>
 
                 <div class="form-check">
-                  <input class="form-check-input" type="checkbox" id="cbDeleteCommands" onchange="saveCheckbox(event)" />
+                  <input class="form-check-input" type="checkbox" id="cbDeleteCommands" onchange="saveCheckbox(this)" />
                   <label class="form-check-label" for="cbDeleteCommands">
                     Delete all channel commands that start with !
                   </label>
                 </div>
 
                 <div class="form-check">
-                  <input class="form-check-input" type="checkbox" id="cbEveryoneTTS" onchange="saveCheckbox(event)" checked />
+                  <input class="form-check-input" type="checkbox" id="cbEveryoneTTS" onchange="saveCheckbox(this)" checked />
                   <label class="form-check-label" for="cbEveryoneTTS">
                     Allow Everyone to use TTS
                   </label>
                 </div>
 
                 <div class="form-check">
-                  <input class="form-check-input" type="checkbox" id="cbModTTS" onchange="saveCheckbox(event)" checked />
+                  <input class="form-check-input" type="checkbox" id="cbModTTS" onchange="saveCheckbox(this)" checked />
                   <label class="form-check-label" for="cbModTTS">
                     Allow Mods to use TTS
                   </label>
                 </div>
 
                 <div class="form-check">
-                  <input class="form-check-input" type="checkbox" id="cbVipTTS" onchange="saveCheckbox(event)" checked />
+                  <input class="form-check-input" type="checkbox" id="cbVipTTS" onchange="saveCheckbox(this)" checked />
                   <label class="form-check-label" for="cbVipTTS">
                     Allow Vips to use TTS
                   </label>
                 </div>
 
                 <div class="form-check">
-                  <input class="form-check-input" type="checkbox" id="cbSubTTS" onchange="saveCheckbox(event)" checked />
+                  <input class="form-check-input" type="checkbox" id="cbSubTTS" onchange="saveCheckbox(this)" checked />
                   <label class="form-check-label" for="cbSubTTS">
                     Allow Subs to use TTS
                   </label>
                 </div>
 
                 <div class="form-check">
-                  <input class="form-check-input" type="checkbox" id="cbSpeakReplies" onchange="saveCheckbox(event)" />
+                  <input class="form-check-input" type="checkbox" id="cbSpeakReplies" onchange="saveCheckbox(this)" />
                   <label class="form-check-label" for="cbSpeakReplies">
                     Speak replies and @name references at start of message.
                   </label>
                 </div>
 
                 <div class="form-check d-inline-block">
-                  <input class="form-check-input" type="checkbox" id="cbSpeakEmotesTTS" onchange="saveCheckbox(event)" checked />
+                  <input class="form-check-input" type="checkbox" id="cbSpeakEmotesTTS" onchange="saveCheckbox(this)" checked />
                   <label class="form-check-label" for="cbSpeakEmotesTTS">
                     Speak emotes
                   </label>
                 </div>
                 <div class="form-check d-inline-block">
-                  <input class="form-check-input" type="checkbox" id="cbDedupEmotesTTS" onchange="saveCheckbox(event)" checked />
+                  <input class="form-check-input" type="checkbox" id="cbDedupEmotesTTS" onchange="saveCheckbox(this)" checked />
                   <label class="form-check-label" for="cbDedupEmotesTTS">
                     Dedup emotes
                   </label>
                 </div>
 
                 <div class="form-check">
-                  <input class="form-check-input" type="checkbox" id="cbCleanupTranslation" onchange="saveCheckbox(event)" />
+                  <input class="form-check-input" type="checkbox" id="cbCleanupTranslation" onchange="saveCheckbox(this)" />
                   <label class="form-check-label" for="cbCleanupTranslation">
                     If translation is identical to original message don't translate.
                   </label>
                 </div>
 
                 <div class="form-check">
-                  <input class="form-check-input" type="checkbox" id="cbUserLevDistance" onchange="saveCheckbox(event)" checked />
+                  <input class="form-check-input" type="checkbox" id="cbUserLevDistance" onchange="saveCheckbox(this)" checked />
                   <label class="form-check-label" for="cbUserLevDistance">
                     Don't speak user message if they are a % similar to the last messages in the last X seconds.
                     (Levenshtein distance)
@@ -171,7 +171,7 @@
                     class="form-control"
                     value="90"
                     placeholder="90"
-                    oninput="saveTextField(event)"
+                    oninput="saveTextField(this)"
                   /></label>
                 <label for="txtUserLevTime">
                   Time:
@@ -183,12 +183,12 @@
                     class="form-control"
                     value="300"
                     placeholder="300"
-                    oninput="saveTextField(event)"
+                    oninput="saveTextField(this)"
                   /></label>
 
                 <div class="form-check">
                   <input class="form-check-input" type="checkbox" id="cbChatLevDistance"
-                         onchange="saveCheckbox(event)" checked/>
+                         onchange="saveCheckbox(this)" checked/>
                   <label class="form-check-label" for="cbChatLevDistance">
                     Don't speak chat messages if they are a % similar to the last messages in the last X seconds.
                     (Levenshtein distance)
@@ -204,7 +204,7 @@
                     class="form-control"
                     value="90"
                     placeholder="90"
-                    oninput="saveTextField(event)"
+                    oninput="saveTextField(this)"
                   /></label>
                 <label for="txtChatLevTime">
                   Time:
@@ -216,7 +216,7 @@
                     class="form-control"
                     value="300"
                     placeholder="300"
-                    oninput="saveTextField(event)"
+                    oninput="saveTextField(this)"
                   /></label>
               </div>
 
@@ -224,14 +224,14 @@
                 <div class="form-group">
                   These options require microphone access:<br />
                   <div class="form-check">
-                    <input class="form-check-input" type="checkbox" id="cbPauseTTSOnSpeech" onchange="saveCheckbox(event)" checked />
+                    <input class="form-check-input" type="checkbox" id="cbPauseTTSOnSpeech" onchange="saveCheckbox(this)" checked />
                     <label class="form-check-label" for="cbPauseTTSOnSpeech">
                       Pause TTS when speaking. (Must allow mic access and choose correct mic input)
                     </label>
                   </div>
 
                   <div class="form-check">
-                    <input class="form-check-input" type="checkbox" id="cbPoofMessage" onchange="saveCheckbox(event)" />
+                    <input class="form-check-input" type="checkbox" id="cbPoofMessage" onchange="saveCheckbox(this)" />
                     <label class="form-check-label" for="cbPoofMessage">
                       Say "poof" message to stop speaking a message and continue.
                     </label>
@@ -243,11 +243,11 @@
                     class="form-control"
                     value="(poof|proof|poop)"
                     placeholder="example regex: (poof|proof|poop)"
-                    onchange="saveTextField(event)"
+                    onchange="saveTextField(this)"
                   /></label>
 
                   <div class="form-check">
-                    <input class="form-check-input" type="checkbox" id="cbBanHammer" onchange="saveCheckbox(event)" />
+                    <input class="form-check-input" type="checkbox" id="cbBanHammer" onchange="saveCheckbox(this)" />
                     <label class="form-check-label" for="cbBanHammer">
                       Say "ban" message to stop speaking and speak "ban confirmation" message.
                     </label>
@@ -259,7 +259,7 @@
                     class="form-control"
                     value="(band hammer|ben hammer|ban hammer|banhammer|ben hammer|jan hammer)"
                     placeholder="example regex: (ben hammer|ban hammer|banhammer|ben hammer|jan hammer)"
-                    oninput="saveTextField(event)"
+                    oninput="saveTextField(this)"
                   /></label>
                   <label class="d-block mb-4"><input
                     type="text"
@@ -268,11 +268,11 @@
                     class="form-control"
                     value="(affirmative)"
                     placeholder="example regex: (affirmative)"
-                    oninput="saveTextField(event)"
+                    oninput="saveTextField(this)"
                   /></label>
 
                   <div class="form-check">
-                    <input class="form-check-input" type="checkbox" id="cbSTTS" onchange="saveCheckbox(event)" />
+                    <input class="form-check-input" type="checkbox" id="cbSTTS" onchange="saveCheckbox(this)" />
                     <label class="form-check-label" for="cbSTTS">
                       Use Webkit Voice Recognition and speak result in system language and voice. (Must allow mic access and
                       choose correct mic input)
@@ -280,7 +280,7 @@
                   </div>
 
                   <div class="form-check">
-                    <input class="form-check-input" type="checkbox" id="cbSendDictationTranslation" onchange="saveCheckbox(event)" />
+                    <input class="form-check-input" type="checkbox" id="cbSendDictationTranslation" onchange="saveCheckbox(this)" />
                     <label class="form-check-label" for="cbSendDictationTranslation">
                       Send Dictation Text and Translation to Channel (Be aware this will send translations to any channel
                       connected)
@@ -289,7 +289,7 @@
 
                   <div class="form-check">
                     <input class="form-check-input" type="checkbox" id="cbSendTextToWebsocket"
-                           onchange="saveCheckbox(event); enableCustomWebsocket(this.checked);"
+                           onchange="saveCheckbox(this); enableCustomWebsocket(this.checked);"
                     />
                     <label class="form-check-label" for="cbSendTextToWebsocket">
                       Send spoken text to websocket for comannds.
@@ -301,13 +301,14 @@
                     class="form-control"
                     value="ws://localhost:1880/stt"
                     placeholder="ws://localhost:1880/stt"
+                    oninput="saveTextField(this)"
                   /></label>
 
                   <div class="form-check">
                     <input class="form-check-input"
                       type="checkbox"
                       id="cbSendTextToAWSWebsocket"
-                      onchange="saveCheckbox(event); enableAWSWebsocket(this.checked);"
+                      onchange="saveCheckbox(this); enableAWSWebsocket(this.checked);"
                     />
                     <label class="form-check-label" for="cbSendTextToAWSWebsocket">
                       Send spoken text to AWS for end user clients.
@@ -319,6 +320,7 @@
                     class="form-control"
                     value="wss://api.tts.bot"
                     placeholder="wss://api.tts.bot"
+                    oninput="saveTextField(this)"
                   /></label>
 
                   <a href="node-red-example-command-flow.json">Example Node-RED Command Flow</a>
@@ -714,8 +716,8 @@
         await request.send(null);
       }
 
-      function saveCheckbox(event) {
-        localStorage.setItem(event.target.id, document.getElementById(event.target.id).checked);
+      function saveCheckbox(element) {
+        localStorage.setItem(element.id, element.checked);
       }
 
       function loadCheckboxes() {
@@ -730,8 +732,8 @@
         }
       }
 
-      function saveTextField(event) {
-        localStorage.setItem(event.target.id, document.getElementById(event.target.id).value);
+      function saveTextField(element) {
+        localStorage.setItem(element.id, element.value);
       }
 
       function loadTextFields() {


### PR DESCRIPTION
Bootstrap 5 uses a different markup for checkboxes and added some missing labels (phpstorm is yelling because of them).

Also changed the save functions to accept an element and pass it directly in the event handlers rather than using it from the event target.