### PR TITLE
Wrap chat messages that are too long

### DIFF
--- a/webfront/styles.css
+++ b/webfront/styles.css
@@ -123,6 +123,7 @@ table td {
 
 #livechatc .message {
   border-radius: 5px;
+  overflow-wrap: anywhere;
 }
 
 .settings-toggle {


### PR DESCRIPTION
If some guy spams the chat with a very long string that doesn't contain any breakable character like a space, it will cause the chat box to expand in a way that the buttons become unreachable and are not usable anymore.

This fixes the issue.